### PR TITLE
fix: absolute positioning causing bug with cart div on smaller screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -22,7 +22,8 @@ h1 {
 }
 
 div.desserts {
-  position: absolute;
+  /* problematic line below. test at screen width 550px */
+  /* position: absolute; */
   float: left;
   max-width: 55%;
 }


### PR DESCRIPTION
I spotted the problematic line in the CSS file `line 25` and commented it out. I tested to see if the error was fixed on a screen width of `550px`.